### PR TITLE
Add one-stop conversion within docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Editor backup files
+*~
+
+# generated mzML file:
+MBSpectra.mzML
+allMBFiles/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 1. Downloading Massbank
 ```     
-svn checkout http://www.massbank.jp/SVN/OpenData/record/
+git clone https://github.com/MassBank/MassBank-data
 ```
 ## 2. Copying all the individual Massbank records into allMBFiles folder
 For windows :     
@@ -10,9 +10,17 @@ http://stackoverflow.com/questions/585091/using-xcopy-to-copy-files-from-several
 
 For Mac/Unix :     
 http://unix.stackexchange.com/questions/67503/move-all-files-with-a-certain-extension-from-multiple-subdirectories-into-one-di
+
 ## 3. use python script to generate mzML
 ```     
 python parseMBFiles.py allMBFiles/
+```
+
+As docker conversion from https://github.com/MassBank/MassBank-data
+all-in-one. From within the checked-out working copy of MassBankUpdate:
+
+```
+docker run --rm -v $PWD:/MBU hroest/openms-pyopenms-v2.2.0 /MBU/convert-massbank.sh'
 ```
 
 Note : For updating MB2HMDBmapping.csv you need to update HMDB first : 

--- a/convert-massbank.sh
+++ b/convert-massbank.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+##
+## Download snapshot of MassBank data
+##
+
+cd /tmp
+git clone https://github.com/MassBank/MassBank-data.git
+
+##
+## Collect all MassBank files in one folder
+##
+
+cd /MBU
+
+## Nuke MB collection directory
+rm -rf allMBFiles/
+mkdir allMBFiles
+
+find /tmp/MassBank-data -name "*.txt" | xargs -I filename ln -s filename allMBFiles/
+
+##
+## actual conversion
+##
+
+python parseMBFiles.py allMBFiles/
+


### PR DESCRIPTION
Update data retrieval instructions in the README, 
Add a wrapper script for `git clone`, linking into one directory 
and executing conversion.